### PR TITLE
Add One Dark to list of Themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Dark theme featuring soft pastel colors built to be imported as a Standard Notes
 * [sn-theme-minimal](https://github.com/ajh3/sn-theme-minimal) - A minimal theme
 * [sn-themes](https://github.com/orestarod/sn-themes) - Some community themes and detail of how to develop your own
 * [Uniform Dark+ Theme](https://gitlab.com/dark-themes/uniform-dark-theme-sn) - Theme inspired by Visual Studio Code's default dark theme, designed for Standard Notes.
+* [One Dark](https://github.com/matta9001/sn-onedark) - One Dark color scheme based on Atom.
 * [One Dark Darker](https://github.com/eenpadvinder/standardnotes-theme-one-darker) - Based on the One Dark Darker theme for VS Code, with colored headings and some UI tweaks.
 * [Tangerine Theme](https://github.com/shompoe/sn-tangerine-theme) - I created this theme to tweak some of the colours from Gruvbox Dark Theme and to give note flags coloured backgrounds in desktop.
 * [Nord Theme](https://github.com/lzambarda/sn-nord-theme) - Nord Theme for Standard Notes, inspired by the beautiful Nord palette.


### PR DESCRIPTION
There was no good default "One Dark" color scheme for Standard Notes, so I made one myself based on the most ubiquitous color palette I could find.