### PR TITLE
Add markdown-monospace theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Please take a look at the [contribution guidelines](CONTRIBUTING.md) before sugg
 * [sn-less-distraction](https://github.com/alecstein/sn-less-distraction) - A reduced version of the [No Distraction](https://standardnotes.org/extensions/no-distraction) theme which layers with other themes. The font is also little larger.
 * [One Light Lighter](https://github.com/arturolinares/standardnotes-theme-one-lighter) - Based on One Dark Darker (listed above), but with a light background.
 * [Yaru](https://github.com/ceiphr/sn-yaru-theme) - Based on Ubuntu's Yaru Theme, with a dark background. 
+* [Monospace for Markdown Editors](https://github.com/DanielNetoP/markdown-monospace) - Monospace font for Standard Notes markdown editors (Toggle on top of other themes)
+
 ### Editors
 * [Org mode for Standard Notes](https://github.com/ryanpcmcquen/standardnotes_org_mode_editor)
 * [Standard Notes Indent Editor](https://github.com/MaxLap/standard-notes-indent-editor)


### PR DESCRIPTION
This is a toggable theme to activate monospace only on the following markdown editors (just updates the editor, not the preview):
- Basic Markdown
- Hybrid Markdown
- Minimal Markdown