### PR TITLE
Add project status labels to improve maintenance transparency

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,15 @@ A curated list of tools and information relating to [Standard Notes](https://sta
 
 Please take a look at the [contribution guidelines](CONTRIBUTING.md) before suggesting any changes. You can also have your extension hosted by the [official plugins directory](https://github.com/standardnotes/plugins).
 
+## Status Labels
+
+This list includes projects in various maintenance states. Labels help you understand project availability:
+
+- **[Archived]** - Read-only repository, no longer maintained by the original author
+- **[Unmaintained]** - Repository is dormant but still accessible; may work but receives no updates
+- **[v003 only]** - Only compatible with legacy Standard Notes protocol (pre-November 2020)
+- **[May be unavailable]** - Link may be intermittently unavailable or moved
+
 ### Contents
 - [Awesome Standard Notes](#awesome-standard-notes)
     - [Contents](#contents)
@@ -44,9 +53,9 @@ Please take a look at the [contribution guidelines](CONTRIBUTING.md) before sugg
 * [Gruvbox Dark Theme](https://github.com/christianhans/sn-gruvbox-dark-theme) - Based on colors from the gruvbox theme for Vim.
 * [Monochrome Dark Theme](https://github.com/Parkertg/sn-theme-monochrome-dark)
 * [Muted Dark Theme](https://github.com/ntran/sn-theme-muteddark) - Standard Notes dark theme with non-vivid, muted colors
-* [Pure Black Theme](https://github.com/christianhans/sn-pure-black-theme) - Theme for Standard Notes. Optimized for OLED devices such as iPhone X.
+* [Pure Black Theme](https://github.com/christianhans/sn-pure-black-theme) **[Unmaintained]** - Theme for Standard Notes. Optimized for OLED devices such as iPhone X.
 * [Slate Theme](https://github.com/yithian/slate-theme/) - A Standard Notes theme with shady grey and mossy green highlights.
-* [vscode-theme](https://github.com/hyphone/sn-theme-vscode) - A theme for Standard Notes inspired by the VS Code Dark theme that is easy on the eyes.
+* [vscode-theme](https://github.com/hyphone/sn-theme-vscode) **[Unmaintained]** - A theme for Standard Notes inspired by the VS Code Dark theme that is easy on the eyes.
 * [Subtle Dark Theme](https://github.com/Parkertg/sn-theme-subtle-dark)
 * [Subtle Light Theme](https://github.com/Parkertg/sn-theme-subtle-light)
 * [One Dark Darker](https://github.com/eenpadvinder/standardnotes-theme-one-darker) - Based on the One Dark Darker theme for VS Code, with colored headings and some UI tweaks.
@@ -63,15 +72,15 @@ Please take a look at the [contribution guidelines](CONTRIBUTING.md) before sugg
 * [Official Extensions](https://github.com/standardnotes/plugins)
 * [Org mode for Standard Notes](https://github.com/ryanpcmcquen/standardnotes_org_mode_editor)
 * [Standard Notes Indent Editor](https://github.com/MaxLap/standard-notes-indent-editor)
-* [Standard Notes Nimble Editor](https://hub.darcs.net/jandrew/sn-nimble-editor)
+* [Standard Notes Nimble Editor](https://hub.darcs.net/jandrew/sn-nimble-editor) **[May be unavailable]**
 * [Append Editor](https://github.com/theodorechu/append-editor) - Append to your notes. Write GitHub Flavored Markdown via four different editing modes: Plain Textarea with spell check, in-line formatting provided by [CodeMirror](https://github.com/codemirror/codemirror), what-you-see-is-what-you-get live formatting provided by the [Rich Markdown Editor](https://github.com/outline/rich-markdown-editor) developed by [Outline](https://www.getoutline.com/), and in-line syntax highlighting provided by the [Monaco Editor](https://github.com/microsoft/monaco-editor). In addition to GFM, the Plain Textarea, CodeMirror, and Monaco modes support KaTeX, table of contents, footnotes, in-line HTML, and emoji codes. The Monaco mode also supports autocompletion, search and replace, and syntax highlighting for over 60 programming languages. The Append Editor has built-in support for printing notes and per-note font sizes, font families, and custom CSS.
 * [Flashcard Editor](https://github.com/TheodoreChu/flashcard-editor)
 * [Marp Editor](https://github.com/TheodoreChu/marp-editor) - Create presentation slides with [Marp](https://marp.app) and [Marpit Markdown](https://marpit.marp.app/markdown).
 * [Music Editor](https://github.com/TheodoreChu/music-editor) - Write music with [VexTab](https://github.com/0xfe/vextab) and [VexFlow](https://github.com/0xfe/vexflow).
 * [Rich Markdown Editor](https://github.com/arturolinares/sn-rme) - The awesome editor developed by [Outline](https://www.getoutline.com/). Supports tables, YouTube embeds and text highlights.
 * [Tui Markdown Editor](https://github.com/MortalHappiness/sn-tui.editor) - A markdown editor using [Toast UI Markdown Editor](https://github.com/nhn/tui.editor).
-* [Scratch](https://dylanonelson.github.io/sn-scratch-editor/) - Scratch includes most of the text editing features you would expect for taking notes, like lists, checkboxes, basic text formatting, smart copy/paste, and hotkeys.
-* [Kanban Board](https://github.com/tryonlinux/kanban-board-sn) - A simple Kanban style board editor for Standard Notes.
+* [Scratch](https://dylanonelson.github.io/sn-scratch-editor/) **[May be unavailable]** - Scratch includes most of the text editing features you would expect for taking notes, like lists, checkboxes, basic text formatting, smart copy/paste, and hotkeys.
+* [Kanban Board](https://github.com/tryonlinux/kanban-board-sn) **[Archived]** - A simple Kanban style board editor for Standard Notes.
 * [Kanban Editor](https://github.com/corvec/sn-kanban-editor) - Kanban Editor for Standard Notes. It integrates rcdexta/react-trello, a Kanban board editor, and saves your notes in Markdown so that you can easily read them, export them to Listed, etc.
 * [Home Inventory](https://github.com/tryonlinux/Home-Inventory-sn) - An extension editor for Standard Notes to catalog home inventory (great for insurance purposes) in a solid and secure way.
 * [Coin Inventory](https://github.com/tryonlinux/Coin-Inventory-sn) - An extension editor for Standard Notes to catalog coin inventory in a solid and secure way. Numismatists rejoice!
@@ -93,26 +102,26 @@ Please take a look at the [contribution guidelines](CONTRIBUTING.md) before sugg
 
 ## Tools
 ### Browser
-* [Standard Notes Clipper](https://github.com/johnjones4/Standard-Notes-Clipper) - A browser add-on (Firefox and Chrome) that allows you to clip web pages to your Standard Notes account. 🔻Please note this reported [issue](https://github.com/johnjones4/Standard-Notes-Clipper/issues/34)
-* [Page Link & Title → Note](https://github.com/mllocs/standard-notes-chrome-extension) - Takes the title and link of a web page and creates a note using the same title and inserts the link into the body.
+* [Standard Notes Clipper](https://github.com/johnjones4/Standard-Notes-Clipper) **[Archived]** - A browser add-on (Firefox and Chrome) that allows you to clip web pages to your Standard Notes account. 🔻Please note this reported [issue](https://github.com/johnjones4/Standard-Notes-Clipper/issues/34)
+* [Page Link & Title → Note](https://github.com/mllocs/standard-notes-chrome-extension) **[Unmaintained]** - Takes the title and link of a web page and creates a note using the same title and inserts the link into the body.
 
 ### Command Line
-* [standardnotes-fs](https://github.com/tannercollin/standardnotes-fs) - Mount your Standard Notes account as a filesystem and edit your notes as plain text files <sub><sup>([SN version 003 only](VERSIONS.md "Not compatible with version 004 accounts: those created or upgraded after Nov 2020"))</sub></sup>
+* [standardnotes-fs](https://github.com/tannercollin/standardnotes-fs) **[Archived]** - Mount your Standard Notes account as a filesystem and edit your notes as plain text files. **Note: No longer functional.** <sub><sup>([SN version 003 only](VERSIONS.md "Not compatible with version 004 accounts: those created or upgraded after Nov 2020"))</sub></sup>
 * [sn-cli](https://github.com/jonhadfield/sn-cli) - Manage notes, tags, and other account operations
 * [sn-dotfiles](https://github.com/jonhadfield/sn-dotfiles) - Sync and manage dotfiles using Standard Notes
-* [Extensions Repository Builder](https://github.com/iganeshk/standardnotes-extensions) - Host Standard Notes extensions on your own server.
+* [Extensions Repository Builder](https://github.com/iganeshk/standardnotes-extensions) **[Archived]** - Host Standard Notes extensions on your own server.
 
 ### Importers, Exporters, and Converters
 * [Day One => Standard Notes Importer](https://github.com/ArneTR/standardnotes_day_one_importer) - Day One JSON Export Importer for Standard Notes
-* [Google Keep™ to StandardNotes Converter](https://github.com/vantezzen/Google-Keep-to-Standardnotes-Converter) - Convert Google Keep Takeout archive into Standardnotes archive
-* [simplenote2standardnote](https://github.com/edas/simplenote2standardnote) - Port a SimpleNote backup to a StandardNote one, keeping dates and tags
+* [Google Keep™ to StandardNotes Converter](https://github.com/vantezzen/Google-Keep-to-Standardnotes-Converter) **[Archived]** - Convert Google Keep Takeout archive into Standardnotes archive
+* [simplenote2standardnote](https://github.com/edas/simplenote2standardnote) **[Archived]** - Port a SimpleNote backup to a StandardNote one, keeping dates and tags
 * [onestandard](https://github.com/oxhacks/onestandard) - Convert notebooks from OneNote into Standard Notes format.
 * [notexfr](https://github.com/rafaelespinoza/notexfr) - notexfr is a tool to convert and adapt data for transfer between note-taking services
 * [Google Keep to Standard Notes nodeJS converter](https://standardnotes.com/help/35/how-can-i-import-my-notes-from-google-keep) - Simple NodeJS script to convert a Google Keep Takeout export into a decrypted Standard Notes backup (Now part of StandardNotes).
 * [evernote2md](https://github.com/wormi4ok/evernote2md) - Evernote2md is a CLI tool to convert Evernote notes exported in *.enex format to a directory with markdown files.
 * [Aegis to TokenVault](https://gist.github.com/kahnwong/e94933bb80888e4b7f75df4d90645cbe) - Export secret keys and account info from Aegis, then use this python script to format it into something the TokenVault Editor can use.
 * [Yarle - The ultimate converter of Evernote notes to Markdown](https://github.com/akosbalasko/yarle) - A fully configurable cross-platform desktop application to convert your Evernote notebooks (enex files) to Markdown format.
-* [Standard Notes Folder Export CLI](https://github.com/BrunoBernardino/standardnotes-folder-export-cli#standard-notes-folder-export-cli---deno) - Simple CLI script to convert a decrypted Standard Notes Backup/Export into a structure of `<tag>/<note-title>.<file-extension>`.
+* [Standard Notes Folder Export CLI](https://github.com/BrunoBernardino/standardnotes-folder-export-cli#standard-notes-folder-export-cli---deno) **[Archived]** - Simple CLI script to convert a decrypted Standard Notes Backup/Export into a structure of `<tag>/<note-title>.<file-extension>`.
 * [Standard Notes export to folder](https://github.com/danielnetop/sn-export-to-folder) - CLI tool to extract info from the Standard Notes decrypted export and transform it into folder based tags and notes. After the tool runs the tags will be folders and each note will be inside the respective folder.
 * [BB10 Remember → Standard Notes plaintext(/super note) import format Converter](https://github.com/jayb-g/bbrem2sn) - A simple python program to convert BlackBerry10 Remember Notes backup(backed-up using Runisoft Ultimate Backup on BB10) to Standard Notes importable format with preserved formatting, attachments and timestamps.
 


### PR DESCRIPTION
## Summary
- Added Status Labels legend section explaining project maintenance states
- Labeled 12 projects with appropriate status indicators for better user guidance
- Added special note for standardnotes-fs indicating it's no longer functional

## Changes
**Status Labels Legend:**
- `[Archived]` - Read-only repository, no longer maintained
- `[Unmaintained]` - Dormant but accessible, may work but receives no updates
- `[v003 only]` - Legacy protocol compatibility only
- `[May be unavailable]` - Link may be intermittently unavailable

**Projects Labeled:**
- **[Archived] (7 projects):** standardnotes-fs, standardnotes-extensions, Standard-Notes-Clipper, kanban-board-sn, Google-Keep-to-Standardnotes-Converter, simplenote2standardnote, standardnotes-folder-export-cli
- **[Unmaintained] (3 projects):** sn-theme-vscode, standard-notes-chrome-extension, sn-pure-black-theme
- **[May be unavailable] (2 projects):** sn-nimble-editor, sn-scratch-editor

## Benefits
- Users can quickly identify which projects are actively maintained
- Reduces confusion about project availability and compatibility
- Improves the overall quality and usability of the awesome list

🤖 Generated with [Claude Code](https://claude.com/claude-code)